### PR TITLE
feat(homelab-ci): add envsubst support via gettext-base

### DIFF
--- a/images/homelab-ci/Dockerfile
+++ b/images/homelab-ci/Dockerfile
@@ -40,7 +40,7 @@ mv bin/task /usr/local/bin/task;
 FROM debian:trixie-slim AS ci
 WORKDIR /workspace
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      ca-certificates curl git openssh-client \
+      ca-certificates curl git openssh-client gettext-base \
   && update-ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 COPY --from=downloader /usr/local/bin/tofu /usr/local/bin/tofu


### PR DESCRIPTION
## Summary
- Install `gettext-base` in `images/homelab-ci/Dockerfile`
- This adds `envsubst` to the `brsalcedom/homelab-ci` runtime image

## Why
`lxc-monitoring-bootstrap` workflow renders `config.toml` using `envsubst`. The current image did not include it.

## Result
Workflows using `brsalcedom/homelab-ci` can render templates with `envsubst` without installing extra packages at runtime.